### PR TITLE
Forward compatibility with react/event-loop 1.0 and 0.5 while still supporting 0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-curl": "*",
         "ext-mbstring": "*",
         "ratchet/pawl": "^0.3.1",
-        "react/event-loop": "^0.4.3",
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4.3",
         "react/promise": "^2.5.1",
         "guzzlehttp/guzzle": "^6.3.2",
         "charlottedunois/eventemitter": "^0.1.4",


### PR DESCRIPTION
**Pull Request description:**
Updated `react/event-loop` targeting so current targeted, current event loop release, and future `1.0` releases are supported.

**Why should this Pull Request be merged:**
It keeps this project up to date with the latest `react/event-loop` and compatible with the upcoming first `1.0` release. Which is a retag of near future 0.5.x release.

**Semantic Versioning Classification:**
- [ ] This PR includes major breaking changes (such as method changes)
- [ ] This PR includes **only** documentational changes (such as docblocks, README, etc.)
