### PR TITLE
Fix Collection::implode behaviour.

### DIFF
--- a/src/Utils/Collection.php
+++ b/src/Utils/Collection.php
@@ -409,11 +409,12 @@ class Collection implements \Countable, \Iterator {
             } elseif(\is_object($val)) {
                 $data .= $glue.$val->$col;
             } else {
+                $glue = $col;
                 $data .= $col.$val;
             }
         }
         
-        return \rtrim($data, $glue);
+        return \substr($data, \strlen($glue));
     }
     
     /**


### PR DESCRIPTION
**Pull Request description:**
Fix issue #53.

```php
php > $foo = new \CharlotteDunois\Yasmin\Utils\Collection([['k' => 'a'], ['k' => 'b'], ['k' => 'c']]);
php > echo $foo->implode('k', ', '), "\n";
a, b, c
php > 
```

```php
php > $foo = new \CharlotteDunois\Yasmin\Utils\Collection(['a', 'b', 'c,,,,']);                                                                                                                                                                    
php > echo $foo->implode('|'), "\n";                                                                                                                                                                                                               
a|b|c,,,,                                                                                                                                                                                                                                          
php > 
```

**Why should this Pull Request be merged:**
Fixes issue #53 

**Semantic Versioning Classification:**
- [ ] This PR includes major breaking changes (such as method changes)
- [ ] This PR includes **only** documentational changes (such as docblocks, README, etc.)
