### PR TITLE
Fixes unserialize on Client not working

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -359,6 +359,7 @@ class Client implements \CharlotteDunois\Events\EventEmitterInterface, \Serializ
             $this->$name = $val;
         }
         
+        // ONLY use this if you know to 100% the consequences and know what you are doing
         if(($this->options['internal.ws.disable'] ?? false) !== true) {
             $this->setupWebSocket($this->options['internal.ws.instance'] ?? []);
         }
@@ -1061,7 +1062,6 @@ class Client implements \CharlotteDunois\Events\EventEmitterInterface, \Serializ
      * @return void
      */
     protected function setupWebSocket(array $instance) {
-        // ONLY use this if you know to 100% the consequences and know what you are doing
         if(!empty($instance)) {
             if(\is_string($instance)) {
                 $ws = $instance;

--- a/src/Client.php
+++ b/src/Client.php
@@ -351,7 +351,7 @@ class Client implements \CharlotteDunois\Events\EventEmitterInterface, \Serializ
         \CharlotteDunois\Yasmin\Models\ClientBase::$serializeClient = $this;
         $this->loop = \React\EventLoop\Factory::create();
         
-        $this->shards = new \CharlotteDunois\Yasmin\Utils\Collection();
+        $this->shards = new \CharlotteDunois\Collect\Collection();
         
         $vars = \unserialize($vars);
         

--- a/src/Client.php
+++ b/src/Client.php
@@ -262,7 +262,7 @@ class Client implements \CharlotteDunois\Events\EventEmitterInterface, \Serializ
         
         // ONLY use this if you know to 100% the consequences and know what you are doing
         if(($options['internal.ws.disable'] ?? false) !== true) {
-            $this->setupWebSocket($options['internal.ws.instance'] ?? []);
+            $this->setupWebSocket($options['internal.ws.instance'] ?? null);
         }
         
         $this->checkOptionsStorages();

--- a/src/Client.php
+++ b/src/Client.php
@@ -361,7 +361,7 @@ class Client implements \CharlotteDunois\Events\EventEmitterInterface, \Serializ
         
         // ONLY use this if you know to 100% the consequences and know what you are doing
         if(($this->options['internal.ws.disable'] ?? false) !== true) {
-            $this->setupWebSocket($this->options['internal.ws.instance'] ?? []);
+            $this->setupWebSocket($this->options['internal.ws.instance'] ?? null);
         }
         
         if(!empty($this->options['internal.api.instance'])) {
@@ -1058,10 +1058,10 @@ class Client implements \CharlotteDunois\Events\EventEmitterInterface, \Serializ
     
     /**
      * Setup the websocket, assumes internal.qs.disable is not true
-     * @param array $instance
+     * @param null|string|\CharlotteDunois\Yasmin\WebSocket\WSManager $instance
      * @return void
      */
-    protected function setupWebSocket(array $instance) {
+    protected function setupWebSocket($instance) {
         if(!empty($instance)) {
             if(\is_string($instance)) {
                 $ws = $instance;


### PR DESCRIPTION
**Pull Request description:**
After `serialize` and `unserialize` things don't quite work, looking into the methods revealed `ws.instance` and shards weren't being remade like they are in `__construct`.

Changes:
 - Moved WebSocket instantiation to separate function, referencing it in both `__construct` and `unserialize`
- Remakes shards in `unserialize` as they are null at this point as `serialize` unsets them

**Why should this Pull Request be merged:**
Fixes non-working functionality

**Semantic Versioning Classification:**
- [x] This PR includes major breaking changes (such as method changes)
- [ ] This PR includes **only** documentational changes (such as docblocks, README, etc.)
