### PR TITLE
Removes Invite revoked field

### DIFF
--- a/src/Models/Invite.php
+++ b/src/Models/Invite.php
@@ -19,7 +19,6 @@ namespace CharlotteDunois\Yasmin\Models;
  * @property \CharlotteDunois\Yasmin\Models\User|null                                                                $inviter             The inviter, or null.
  * @property int|null                                                                                                $maxUses             Maximum uses until the invite expires, or null.
  * @property int|null                                                                                                $maxAge              Duration (in seconds) until the invite expires, or null.
- * @property bool|null                                                                                               $revoked             If the invite is revoked, this will indicate it, or null.
  * @property bool|null                                                                                               $temporary           If this invite grants temporary membership, or null.
  * @property int|null                                                                                                $uses                Number of times this invite has been used, or null.
  * @property int|null                                                                                                $presenceCount       Approximate amount of presences, or null.
@@ -72,12 +71,6 @@ class Invite extends ClientBase {
     protected $maxAge;
     
     /**
-     * If the invite is revoked, this will indicate it, or null.
-     * @var bool
-     */
-    protected $revoked;
-    
-    /**
      * If this invite grants temporary membership, or null.
      * @var bool
      */
@@ -115,7 +108,6 @@ class Invite extends ClientBase {
         $this->inviter = (!empty($invite['inviter']) ? $client->users->patch($invite['inviter']) : null);
         $this->maxUses = $invite['max_uses'] ?? null;
         $this->maxAge = $invite['max_age'] ?? null;
-        $this->revoked = $invite['revoked'] ?? null;
         $this->temporary = $invite['temporary'] ?? null;
         $this->uses = $invite['uses'] ?? null;
         


### PR DESCRIPTION
**Pull Request description:**
An invite does not have a `revoked` field and therefore we should remove it. It was just recently removed from the documentation, because it was invalid - the field was never there.

**Why should this Pull Request be merged:**
Solves issue #133

**Semantic Versioning Classification:**
- [x] This PR includes major breaking changes (such as method changes)
- [ ] This PR includes **only** documentational changes (such as docblocks, README, etc.)
