### PR TITLE
Removal of serialize and unserialize methods from Client and Storage

### DIFF
--- a/src/Models/ClientBase.php
+++ b/src/Models/ClientBase.php
@@ -22,6 +22,12 @@ abstract class ClientBase extends Base {
     protected $client;
     
     /**
+     * The client which will be used to unserialize.
+     * @var \CharlotteDunois\Yasmin\Client|null
+     */
+    public static $serializeClient;
+    
+    /**
      * @internal
      */
     function __construct(\CharlotteDunois\Yasmin\Client $client) {
@@ -81,6 +87,12 @@ abstract class ClientBase extends Base {
      * @internal
      */
     function unserialize($data) {
+        if(self::$serializeClient === null) {
+            throw new \Exception('Unable to unserialize a class without ClientBase::$serializeClient being set');
+        }
+        
         parent::unserialize($data);
+        
+        $this->client = self::$serializeClient;
     }
 }

--- a/src/Models/ClientBase.php
+++ b/src/Models/ClientBase.php
@@ -22,12 +22,6 @@ abstract class ClientBase extends Base {
     protected $client;
     
     /**
-     * The client which will be used to unserialize.
-     * @var \CharlotteDunois\Yasmin\Client|null
-     */
-    public static $serializeClient;
-    
-    /**
      * @internal
      */
     function __construct(\CharlotteDunois\Yasmin\Client $client) {
@@ -87,12 +81,6 @@ abstract class ClientBase extends Base {
      * @internal
      */
     function unserialize($data) {
-        if(self::$serializeClient === null) {
-            throw new \Exception('Unable to unserialize a class without ClientBase::$serializeClient being set');
-        }
-        
         parent::unserialize($data);
-        
-        $this->client = self::$serializeClient;
     }
 }

--- a/src/Models/Storage.php
+++ b/src/Models/Storage.php
@@ -13,7 +13,7 @@ namespace CharlotteDunois\Yasmin\Models;
  * Base class for all storages.
  */
 class Storage extends \CharlotteDunois\Collect\Collection
-    implements \CharlotteDunois\Yasmin\Interfaces\StorageInterface, \Serializable {
+    implements \CharlotteDunois\Yasmin\Interfaces\StorageInterface {
     
     /**
      * The client this storage belongs to.
@@ -67,37 +67,6 @@ class Storage extends \CharlotteDunois\Collect\Collection
         }
         
         throw new \RuntimeException('Unknown property '.\get_class($this).'::$'.$name);
-    }
-    
-    /**
-     * @return string
-     * @internal
-     */
-    function serialize() {
-        $vars = \get_object_vars($this);
-        
-        unset($vars['client'], $vars['timer']);
-        $vars['baseStorageArgs'][0] = null;
-        
-        return \serialize($vars);
-    }
-    
-    /**
-     * @return void
-     * @internal
-     */
-    function unserialize($data) {
-        if(\CharlotteDunois\Yasmin\Models\ClientBase::$serializeClient === null) {
-            throw new \Exception('Unable to unserialize a class without ClientBase::$serializeClient being set');
-        }
-        
-        $data = \unserialize($data);
-        foreach($data as $name => $val) {
-            $this->$name = $val;
-        }
-        
-        $this->client = \CharlotteDunois\Yasmin\Models\ClientBase::$serializeClient;
-        $this->baseStorageArgs[0] = $this->client;
     }
     
     /**


### PR DESCRIPTION
Removal of serialize and unserialize methods from Client and Storage, fixes #115

**Pull Request description:**
Really wasn't too sure about this one. `Client` was fine to remove the methods from but had implications for `ClientBase `(removal of `$serializeClient`), which then had implications for `Storage`.

I have removed `Storage` Serialization for the fact that the data can be received from the extending `Collection` class with the `all` method, then you can remake the `Storage` object passing back in the data you stored and with a fresh client object.

My main aim here is to make sure things like `Message` are still serializable, this was a big thing for me a while ago and I can still see many use cases for it.

Let me know if I should make `Storage` implement `\Serializable` again without the `unserialize` method - I'm not 100% sure on what to do here but thought I'd give it a shot!

I haven't actually tested this, _yet_, but I will at some point soon (< 48 hr) if you don't get around to it first. Was hoping for some feedback in the meantime.

**Why should this Pull Request be merged:**
Fixes #115

**Semantic Versioning Classification:**
- [x] This PR includes major breaking changes (such as method changes)
- [ ] This PR includes **only** documentational changes (such as docblocks, README, etc.)
